### PR TITLE
implement walletpassphrase rpc call

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -26,7 +26,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				AssertException<RPCException>(() => rpc.SendCommand("donotexist"), (ex) =>
 				{
@@ -41,7 +41,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				var response = rpc.SendCommand(RPCOperations.getinfo);
 				Assert.NotNull(response.Result);
@@ -53,7 +53,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				var response = rpc.SendCommand(RPCOperations.getblockhash, 0);
 				var actualGenesis = (string)response.Result;
@@ -67,7 +67,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var node = builder.CreateNode();
+				var node = builder.CreateNode(true);
 				var rpc = node.CreateRPCClient();
 				builder.StartAll();
 				node.Generate(101);
@@ -97,7 +97,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				var response = rpc.GetBlockHeader(0);
 				AssertEx.CollectionEquals(Network.RegTest.GetGenesis().Header.ToBytes(), response.ToBytes());
@@ -183,7 +183,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				var blockId = rpc.GetBestBlockHash();
 				var block = rpc.GetBlock(blockId);
@@ -196,7 +196,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				Key key = new Key();
 				rpc.ImportAddress(key.PubKey.GetAddress(Network.RegTest), TestAccount, false);
@@ -320,7 +320,7 @@ namespace NBitcoin.Tests
 		{
 			using(var builder = NodeBuilder.Create())
 			{
-				var rpc = builder.CreateNode().CreateRPCClient();
+				var rpc = builder.CreateNode(true).CreateRPCClient();
 				builder.StartAll();
 				var tx = Network.TestNet.GetGenesis().Transactions[0];
 

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -115,7 +115,7 @@ namespace NBitcoin.RPC
 		wallet			 signmessage
 		wallet			 walletlock
 		wallet			 walletpassphrasechange
-		wallet			 walletpassphrase
+		wallet			 walletpassphrase			yes
 	*/
 	public partial class RPCClient
 	{
@@ -123,14 +123,14 @@ namespace NBitcoin.RPC
 
 		public void BackupWallet(string path)
 		{
-			if (string.IsNullOrEmpty(path))
+			if(string.IsNullOrEmpty(path))
 				throw new ArgumentNullException("path");
 			SendCommand("backupwallet", path);
 		}
 
 		public async Task BackupWalletAsync(string path)
 		{
-			if (string.IsNullOrEmpty(path))
+			if(string.IsNullOrEmpty(path))
 				throw new ArgumentNullException("path");
 			await SendCommandAsync("backupwallet", path).ConfigureAwait(false);
 		}
@@ -437,7 +437,7 @@ namespace NBitcoin.RPC
 		private IEnumerable<RPCAccount> AsRPCAccount(RPCResponse response)
 		{
 			var obj = (JObject)response.Result;
-			foreach (var prop in obj.Properties())
+			foreach(var prop in obj.Properties())
 			{
 				yield return new RPCAccount()
 				{
@@ -454,14 +454,14 @@ namespace NBitcoin.RPC
 		{
 			var result = SendCommand(RPCOperations.listaddressgroupings);
 			var array = (JArray)result.Result;
-			foreach (var group in array.Children<JArray>())
+			foreach(var group in array.Children<JArray>())
 			{
 				var grouping = new AddressGrouping();
 				grouping.PublicAddress = BitcoinAddress.Create(group[0][0].ToString());
 				grouping.Amount = Money.Coins(group[0][1].Value<decimal>());
 				grouping.Account = group[0].Count() > 2 ? group[0][2].ToString() : null;
 
-				foreach (var subgroup in group.Skip(1))
+				foreach(var subgroup in group.Skip(1))
 				{
 					var change = new ChangeAddress();
 					change.Address = BitcoinAddress.Create(subgroup[0].ToString());
@@ -475,10 +475,10 @@ namespace NBitcoin.RPC
 
 		public IEnumerable<BitcoinSecret> ListSecrets()
 		{
-			foreach (var grouping in ListAddressGroupings())
+			foreach(var grouping in ListAddressGroupings())
 			{
 				yield return DumpPrivKey(grouping.PublicAddress);
-				foreach (var change in grouping.ChangeAddresses)
+				foreach(var change in grouping.ChangeAddresses)
 					yield return DumpPrivKey(change.Address);
 			}
 		}
@@ -512,7 +512,7 @@ namespace NBitcoin.RPC
 			var response = SendCommand("listunspent", minconf, maxconf, addr.ToArray());
 			return response.Result.Select(i => new UnspentCoin((JObject)i, Network)).ToArray();
 		}
-		
+
 		/// <summary>
 		/// Returns an array of unspent transaction outputs belonging to this wallet. 
 		/// </summary>
@@ -577,7 +577,7 @@ namespace NBitcoin.RPC
 			{
 				LockUnspentCoreAsync(unlock, outpoints).Wait();
 			}
-			catch (AggregateException ex)
+			catch(AggregateException ex)
 			{
 				ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
 			}
@@ -585,13 +585,13 @@ namespace NBitcoin.RPC
 
 		private async Task LockUnspentCoreAsync(bool unlock, OutPoint[] outpoints)
 		{
-			if (outpoints == null || outpoints.Length == 0)
+			if(outpoints == null || outpoints.Length == 0)
 				return;
 			var parameters = new List<object>();
 			parameters.Add(unlock);
 			var array = new JArray();
 			parameters.Add(array);
-			foreach (var outp in outpoints)
+			foreach(var outp in outpoints)
 			{
 				var obj = new JObject();
 				obj["txid"] = outp.Hash.ToString();
@@ -599,6 +599,31 @@ namespace NBitcoin.RPC
 				array.Add(obj);
 			}
 			await SendCommandAsync("lockunspent", parameters.ToArray()).ConfigureAwait(false);
+		}
+
+		// walletpassphrase
+
+		/// <summary>
+		/// The walletpassphrase RPC stores the wallet decryption key in memory for the indicated number of seconds.Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock time that overrides the old one.
+		/// </summary>
+		/// <param name="passphrase">The passphrase</param>
+		/// <param name="timeout">Timeout in seconds</param>
+		public void WalletPassphrase(string passphrase, int timeout)
+		{
+			WalletPassphraseAsync(passphrase, timeout).GetAwaiter().GetResult();
+		}
+
+		/// <summary>
+		/// The walletpassphrase RPC stores the wallet decryption key in memory for the indicated number of seconds.Issuing the walletpassphrase command while the wallet is already unlocked will set a new unlock time that overrides the old one.
+		/// </summary>
+		/// <param name="passphrase">The passphrase</param>
+		/// <param name="timeout">Timeout in seconds</param>
+		public async Task WalletPassphraseAsync(string passphrase, int timeout)
+		{
+			var parameters = new List<object>();
+			parameters.Add(passphrase);
+			parameters.Add(timeout);
+			await SendCommandAsync("walletpassphrase", parameters.ToArray()).ConfigureAwait(false);
 		}
 	}
 }

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -123,14 +123,14 @@ namespace NBitcoin.RPC
 
 		public void BackupWallet(string path)
 		{
-			if(string.IsNullOrEmpty(path))
+			if (string.IsNullOrEmpty(path))
 				throw new ArgumentNullException("path");
 			SendCommand("backupwallet", path);
 		}
 
 		public async Task BackupWalletAsync(string path)
 		{
-			if(string.IsNullOrEmpty(path))
+			if (string.IsNullOrEmpty(path))
 				throw new ArgumentNullException("path");
 			await SendCommandAsync("backupwallet", path).ConfigureAwait(false);
 		}
@@ -437,7 +437,7 @@ namespace NBitcoin.RPC
 		private IEnumerable<RPCAccount> AsRPCAccount(RPCResponse response)
 		{
 			var obj = (JObject)response.Result;
-			foreach(var prop in obj.Properties())
+			foreach (var prop in obj.Properties())
 			{
 				yield return new RPCAccount()
 				{
@@ -454,14 +454,14 @@ namespace NBitcoin.RPC
 		{
 			var result = SendCommand(RPCOperations.listaddressgroupings);
 			var array = (JArray)result.Result;
-			foreach(var group in array.Children<JArray>())
+			foreach (var group in array.Children<JArray>())
 			{
 				var grouping = new AddressGrouping();
 				grouping.PublicAddress = BitcoinAddress.Create(group[0][0].ToString());
 				grouping.Amount = Money.Coins(group[0][1].Value<decimal>());
 				grouping.Account = group[0].Count() > 2 ? group[0][2].ToString() : null;
 
-				foreach(var subgroup in group.Skip(1))
+				foreach (var subgroup in group.Skip(1))
 				{
 					var change = new ChangeAddress();
 					change.Address = BitcoinAddress.Create(subgroup[0].ToString());
@@ -475,10 +475,10 @@ namespace NBitcoin.RPC
 
 		public IEnumerable<BitcoinSecret> ListSecrets()
 		{
-			foreach(var grouping in ListAddressGroupings())
+			foreach (var grouping in ListAddressGroupings())
 			{
 				yield return DumpPrivKey(grouping.PublicAddress);
-				foreach(var change in grouping.ChangeAddresses)
+				foreach (var change in grouping.ChangeAddresses)
 					yield return DumpPrivKey(change.Address);
 			}
 		}
@@ -577,7 +577,7 @@ namespace NBitcoin.RPC
 			{
 				LockUnspentCoreAsync(unlock, outpoints).Wait();
 			}
-			catch(AggregateException ex)
+			catch (AggregateException ex)
 			{
 				ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
 			}
@@ -585,13 +585,13 @@ namespace NBitcoin.RPC
 
 		private async Task LockUnspentCoreAsync(bool unlock, OutPoint[] outpoints)
 		{
-			if(outpoints == null || outpoints.Length == 0)
+			if (outpoints == null || outpoints.Length == 0)
 				return;
 			var parameters = new List<object>();
 			parameters.Add(unlock);
 			var array = new JArray();
 			parameters.Add(array);
-			foreach(var outp in outpoints)
+			foreach (var outp in outpoints)
 			{
 				var obj = new JObject();
 				obj["txid"] = outp.Hash.ToString();

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -127,7 +127,7 @@ namespace NBitcoin.RPC
 		wallet			 signmessage
 		wallet			 walletlock
 		wallet			 walletpassphrasechange
-		wallet			 walletpassphrase
+		wallet			 walletpassphrase			yes
 	*/
 	public partial class RPCClient : IBlockRepository
 	{


### PR DESCRIPTION
& Test. This is an implementation based on the one I've done for NBitcoin. We use this in BreezeHub/BreezeServer to facilitate tumbler wallet decryption from config