### PR TITLE
Sidechain Withdraw Transaction

### DIFF
--- a/NBitcoin.Tests/sidechains_tests.cs
+++ b/NBitcoin.Tests/sidechains_tests.cs
@@ -1,0 +1,107 @@
+﻿using NBitcoin.DataEncoders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NBitcoin.Tests
+{
+	public class sidechains
+	{
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public static void CreateWithdrawScript()
+		{
+			// build a sidechain genesis with a locked output of 1000 coins
+
+			Transaction sidechainGenesis = new Transaction();
+			sidechainGenesis.Version = 1;
+			sidechainGenesis.Time = (uint) DateTime.UtcNow.ToUnixTimestamp();
+			sidechainGenesis.AddInput(new TxIn
+			{
+				ScriptSig = new Script(Op.GetPushOp(Encoders.ASCII.DecodeData("Testing a sidechain")))
+			});
+			sidechainGenesis.AddOutput(new TxOut()
+			{
+				Value = Money.Coins(1000),
+				ScriptPubKey = new Script(new Op
+				{
+					Code = OpcodeType.OP_WITHDRAWPROOFVERIFY,
+					//PushData = new[] {(byte) 42}
+
+				})
+			});
+
+			// build a withdraw lock transaction from parent chain that spends 500 coins
+
+			var key = new Key();
+			var network = Network.RegTest;
+
+			// a block that has an output.
+			var block = CreateBlockWithCoinbase(network, network.GetGenesis(), key, 1);
+			var lockTrx = new Transaction();
+			lockTrx.AddInput(new TxIn(new OutPoint(uint256.Zero, 0))); // a fake input that spends 250
+			lockTrx.AddInput(new TxIn(new OutPoint(uint256.Zero, 0))); // a fake input that spends 250
+			lockTrx.AddOutput(new TxOut(Money.Coins(500),
+				new Script(new Op {Code = OpcodeType.OP_WITHDRAWPROOFVERIFY}))); // lock the output
+			// TODO: how do we represent the target on the sidechain?
+			block.AddTransaction(lockTrx);
+			block.UpdateMerkleRoot();
+
+			// mine two more blocks 
+			var block1 = CreateBlockWithCoinbase(network, block, key, 2);
+			var block2 = CreateBlockWithCoinbase(network, block1, key, 3);
+
+			// Create an SPV proof, a transaction that can withdraw to the sidechain
+			var proof = new SpvProof();
+			proof.CoinBase = block.Transactions.First();
+			proof.Lock = lockTrx;
+			var merkleBlock = new MerkleBlock(block, new[] {lockTrx.GetHash()});
+			proof.MerkleProof = merkleBlock.PartialMerkleTree;
+			proof.SpvHeaders = new SpvHeaders {Headers = new List<BlockHeader> {block.Header, block1.Header, block2.Header}};
+			proof.Genesis = network.GenesisHash;
+
+			// verify the transaction script
+
+			var scriptSignature = new Script(
+				Op.GetPushOp(proof.Genesis.ToBytes()),
+				Op.GetPushOp(proof.CoinBase.ToBytes()),
+				Op.GetPushOp(proof.Lock.ToBytes()),
+				Op.GetPushOp(proof.MerkleProof.ToBytes()),
+				Op.GetPushOp(proof.SpvHeaders.ToBytes()));
+
+			var withdrawTrx = new Transaction();
+			withdrawTrx.AddInput(new TxIn(new OutPoint(sidechainGenesis, 0), scriptSignature));
+			withdrawTrx.AddOutput(new TxOut(500, key.ScriptPubKey));
+			withdrawTrx.AddOutput(new TxOut(500, new Script(new Op {Code = OpcodeType.OP_WITHDRAWPROOFVERIFY})));
+
+			var scriptSig = withdrawTrx.Inputs.First().ScriptSig;
+			var output = sidechainGenesis.Outputs.First();
+			var scriptPubKey = sidechainGenesis.Outputs.First().ScriptPubKey;
+
+
+			var result = Script.VerifyScript(scriptSig, scriptPubKey, withdrawTrx, 0);
+
+		}
+
+
+		private static Block CreateBlockWithCoinbase(Network network, Block previous, Key key, int index)
+		{
+			Block block = new Block();
+			block.Header.HashPrevBlock = previous.GetHash(); 
+			var tip = new ChainedBlock(previous.Header, index);
+			block.Header.Bits = block.Header.GetWorkRequired(network, tip);
+			block.Header.UpdateTime(network, tip);
+
+			var coinbase = new Transaction();
+			coinbase.AddInput(TxIn.CreateCoinbase(tip.Height + 1));
+			coinbase.AddOutput(new TxOut(network.GetReward(tip.Height + 1), key));
+			block.AddTransaction(coinbase);
+
+			block.UpdateMerkleRoot();
+
+			return block;
+		}
+	}
+}

--- a/NBitcoin.Tests/sidechains_tests.cs
+++ b/NBitcoin.Tests/sidechains_tests.cs
@@ -57,19 +57,15 @@ namespace NBitcoin.Tests
 			var proof = new SpvProof();
 			proof.CoinBase = block.Transactions.First();
 			proof.Lock = lockTrx;
+			proof.OutputIndex = 0;
 			var merkleBlock = new MerkleBlock(block, new[] {lockTrx.GetHash()});
 			proof.MerkleProof = merkleBlock.PartialMerkleTree;
 			proof.SpvHeaders = new SpvHeaders {Headers = new List<BlockHeader> {block.Header, block1.Header, block2.Header}};
 			proof.Genesis = network.GenesisHash;
-
+			proof.DestinationScript = key.ScriptPubKey;
 			// verify the transaction script
 
-			var scriptSignature = new Script(
-				Op.GetPushOp(proof.Genesis.ToBytes()),
-				Op.GetPushOp(proof.CoinBase.ToBytes()),
-				Op.GetPushOp(proof.Lock.ToBytes()),
-				Op.GetPushOp(proof.MerkleProof.ToBytes()),
-				Op.GetPushOp(proof.SpvHeaders.ToBytes()));
+			var scriptSignature = SpvProof.CreateScript(proof);
 
 			var withdrawTrx = new Transaction();
 			withdrawTrx.AddInput(new TxIn(new OutPoint(sidechainGenesis, 0), scriptSignature));
@@ -81,8 +77,8 @@ namespace NBitcoin.Tests
 			var scriptPubKey = sidechainGenesis.Outputs.First().ScriptPubKey;
 
 
-			var result = Script.VerifyScript(scriptSig, scriptPubKey, withdrawTrx, 0);
-
+			var result = Script.VerifyScript(scriptSig, scriptPubKey, withdrawTrx, 0, output.Value);
+			Assert.True(result);
 		}
 
 

--- a/NBitcoin.Tests/sidechains_tests.cs
+++ b/NBitcoin.Tests/sidechains_tests.cs
@@ -28,8 +28,6 @@ namespace NBitcoin.Tests
 				ScriptPubKey = new Script(new Op
 				{
 					Code = OpcodeType.OP_WITHDRAWPROOFVERIFY,
-					//PushData = new[] {(byte) 42}
-
 				})
 			});
 

--- a/NBitcoin/PartialMerkleTree.cs
+++ b/NBitcoin/PartialMerkleTree.cs
@@ -11,6 +11,14 @@ namespace NBitcoin
 		{
 
 		}
+
+		public PartialMerkleTree(byte[] bytes)
+			: this()
+		{
+			this.FromBytes(bytes);
+		}
+
+
 		uint _TransactionCount;
 		public uint TransactionCount
 		{

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -1,10 +1,10 @@
-﻿using System.Runtime.InteropServices;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace NBitcoin
@@ -308,6 +308,7 @@ namespace NBitcoin
 		OP_NOP2 = 0xb1,
 		OP_NOP3 = 0xb2,
 		OP_NOP4 = 0xb3,
+		OP_WITHDRAWPROOFVERIFY = OP_NOP4,
 		OP_NOP5 = 0xb4,
 		OP_NOP6 = 0xb5,
 		OP_NOP7 = 0xb6,

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1479,9 +1479,14 @@ namespace NBitcoin
 							case OpcodeType.OP_WITHDRAWPROOFVERIFY:
 
 								{
-									// There are two cases
-									// 1. a locking output that will verify the output amount is correct
-									// 2. a spending output that will unlock some coins
+									// This op code expects the following on the stack
+									// 1. a list of spv headers
+									// 2. a MerkleProof of the locking trx on the parent chain
+									// 3. the OutputIndex of the locking trx
+									// 4. the locking trx itself
+									// 5. the CoinBase of the block the lock was confirmed in 
+									// 6. Genesis of parent
+									// 7. ScriptPubKey of the destination script
 
 									if (_stack.Count != 7)
 										return SetError(ScriptError.InvalidStackOperation);

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1499,7 +1499,7 @@ namespace NBitcoin
 										_stack.Pop(), // Lock
 										_stack.Pop(), // CoinBase
 										_stack.Pop(), // Genesis
-										_stack.Pop(), // P2SH target
+										_stack.Pop(), // SciptPubkey target
 									};
 
 									arrayList.Reverse();
@@ -1518,7 +1518,6 @@ namespace NBitcoin
 										return SetError(ScriptError.WithdrawVerifyOutputscript);
 
 									// check that the output value is within the unlocked coins
-
 									var withdrawScript = new Script(new[] {new Op {Code = OpcodeType.OP_WITHDRAWPROOFVERIFY}});
 									var relocks = checker.Transaction.Outputs.Where(o => o.ScriptPubKey == withdrawScript);
 
@@ -1534,7 +1533,6 @@ namespace NBitcoin
 										return SetError(ScriptError.WithdrawVerifyLockTx);
 
 									// check that the coinbase is in the first header
-
 									if (!proof.MerkleProof.Check(first.HashMerkleRoot))
 										return SetError(ScriptError.WithdrawVerifyLockTx);
 

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1472,10 +1472,26 @@ namespace NBitcoin
 									// 2. a spending output that will unlock some coins
 
 
-									if (_stack.Count != 2 )
+									if (_stack.Count != 5)
 										return SetError(ScriptError.InvalidStackOperation);
 
-										break;
+
+									var arrayList = new List<byte[]>
+									{
+										_stack.Pop(),
+										_stack.Pop(),
+										_stack.Pop(),
+										_stack.Pop(),
+										_stack.Pop(),
+									};
+
+									arrayList.Reverse();
+									var proof = SpvProof.CreateProof(arrayList);
+
+									// validate all items.
+
+
+									break;
 								}
 
 							default:

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -823,7 +822,7 @@ namespace NBitcoin
 								}
 
 
-							case OpcodeType.OP_NOP4:
+							//case OpcodeType.OP_NOP4:
 							case OpcodeType.OP_NOP5:
 							case OpcodeType.OP_NOP6:
 							case OpcodeType.OP_NOP7:
@@ -1463,6 +1462,22 @@ namespace NBitcoin
 									}
 									break;
 								}
+
+							case OpcodeType.OP_WITHDRAWPROOFVERIFY:
+
+								{
+
+									// There are two cases
+									// 1. a locking output that will verify the output amount is correct
+									// 2. a spending output that will unlock some coins
+
+
+									if (_stack.Count != 2 )
+										return SetError(ScriptError.InvalidStackOperation);
+
+										break;
+								}
+
 							default:
 								return SetError(ScriptError.BadOpCode);
 						}

--- a/NBitcoin/SpvProof.cs
+++ b/NBitcoin/SpvProof.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace NBitcoin
 {
@@ -19,12 +18,16 @@ namespace NBitcoin
 
     public class SpvProof
     {
-	    public List<BlockHeader> Headers;
+	    public List<BlockHeader> SpvHeaders;
 
-	    public uint256 ParentGenesis;
+	    public uint256 Genesis;
 
 	    public Transaction Lock;
 
-		public MerkleBlock
+	    public Transaction CoinBase;
+
+	    public Transaction CoinStake;
+
+		public PartialMerkleTree MerkleProof;
     }
 }

--- a/NBitcoin/SpvProof.cs
+++ b/NBitcoin/SpvProof.cs
@@ -19,7 +19,12 @@ namespace NBitcoin
 
     public class SpvProof
     {
-	    private List<BlockHeader> Headers;
+	    public List<BlockHeader> Headers;
 
+	    public uint256 ParentGenesis;
+
+	    public Transaction Lock;
+
+		public MerkleBlock
     }
 }

--- a/NBitcoin/SpvProof.cs
+++ b/NBitcoin/SpvProof.cs
@@ -4,20 +4,52 @@ using System.Linq;
 
 namespace NBitcoin
 {
+	/// <summary>
+	/// An SpvProof (Simplified Payment Verification) that is used to proof an output is locked (undependable).
+	/// </summary>
 	public class SpvProof
 	{
+		/// <summary>
+		/// The genesis hash of the chain where the withdraw lock was created.
+		/// </summary>
 		public uint256 Genesis;
 
+		/// <summary>
+		/// A list of headers on the chain that confirmed the withdraw.
+		/// </summary>
+		/// <remarks>
+		/// The first header represents the block that contains the withdraw lock.
+		/// The rest of the headers represent work (how many blocks the withdraw is berried under).
+		/// The headers are expected to be a chained of block headers.
+		/// </remarks>
 		public SpvHeaders SpvHeaders;
 
+		/// <summary>
+		/// A transaction that locked some coins to a special op code <see cref="OpcodeType.OP_WITHDRAWPROOFVERIFY"/>.
+		/// </summary>
 		public Transaction Lock;
 
+		/// <summary>
+		/// The index of the output in the that lock transaction that is being refereed to by this SPV Proof.
+		/// </summary>
 		public int OutputIndex;
 
+		/// <summary>
+		/// The coinbase of the block that confirmed the locked transaction.
+		/// </summary>
+		/// <remarks>
+		/// The coinbase can be used to know the block height of the locked transaction.
+		/// </remarks>
 	    public Transaction CoinBase;
 
+		/// <summary>
+		/// A proof that verifies the locking transaction was included in a block.
+		/// </summary>
 		public PartialMerkleTree MerkleProof;
 
+		/// <summary>
+		/// The recipient of the locking transaction.
+		/// </summary>
 		public Script DestinationScript;
 
 		public static Script CreateScript(SpvProof proof)
@@ -48,7 +80,7 @@ namespace NBitcoin
 			return proof;
 		}
 
-		public static int ReadIndex(byte[] array)
+		private static int ReadIndex(byte[] array)
 		{
 			using (var mem = new MemoryStream(array))
 			{
@@ -59,7 +91,7 @@ namespace NBitcoin
 			}
 		}
 
-		public static byte[] WriteIndex(int number)
+		private static byte[] WriteIndex(int number)
 		{
 			using (var mem = new MemoryStream())
 			{
@@ -70,6 +102,9 @@ namespace NBitcoin
 		}
 	}
 
+	/// <summary>
+	/// A class to serialize a list of block headers.
+	/// </summary>
 	public class SpvHeaders : IBitcoinSerializable
 	{
 		public List<BlockHeader> Headers;

--- a/NBitcoin/SpvProof.cs
+++ b/NBitcoin/SpvProof.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBitcoin
+{
+	public class WithdrawTransaction :IBitcoinSerializable
+	{
+		public uint256 ParentGenesis;
+
+		public SpvProof SpvProof;
+
+
+		public void ReadWrite(BitcoinStream stream)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+    public class SpvProof
+    {
+	    private List<BlockHeader> Headers;
+
+    }
+}

--- a/NBitcoin/SpvProof.cs
+++ b/NBitcoin/SpvProof.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NBitcoin
 {
@@ -17,17 +18,57 @@ namespace NBitcoin
 	}
 
     public class SpvProof
-    {
-	    public List<BlockHeader> SpvHeaders;
+	{
+		public uint256 Genesis;
 
-	    public uint256 Genesis;
+		public SpvHeaders SpvHeaders;
 
-	    public Transaction Lock;
+		public Transaction Lock;
 
 	    public Transaction CoinBase;
 
-	    public Transaction CoinStake;
-
 		public PartialMerkleTree MerkleProof;
-    }
+
+		public static Script CreateScript(SpvProof proof)
+		{
+			var scriptSignature = new Script(
+				Op.GetPushOp(proof.Genesis.ToBytes()),
+				Op.GetPushOp(proof.CoinBase.ToBytes()),
+				Op.GetPushOp(proof.Lock.ToBytes()),
+				Op.GetPushOp(proof.MerkleProof.ToBytes()),
+				Op.GetPushOp(proof.SpvHeaders.ToBytes()));
+
+			return scriptSignature;
+		}
+
+		public static SpvProof CreateProof(IEnumerable<byte[]> stack)
+		{
+			var items = stack.ToArray();
+			var proof = new SpvProof();
+			proof.Genesis = new uint256(items[0]);
+			proof.CoinBase = new Transaction(items[1]);
+			proof.Lock = new Transaction(items[2]);
+			proof.MerkleProof = new PartialMerkleTree(items[3]);
+			proof.SpvHeaders = new SpvHeaders(items[4]);
+			return proof;
+		}
+	}
+
+	public class SpvHeaders : IBitcoinSerializable
+	{
+		public List<BlockHeader> Headers;
+
+		public SpvHeaders()
+		{ }
+
+		public SpvHeaders(byte[] bytes)
+		{
+			this.FromBytes(bytes);
+		}
+
+		public void ReadWrite(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref this.Headers);
+		}
+	}
 }


### PR DESCRIPTION
This includes the initial code to verify an spv proof 
Note: the new op code is not supported by any network attempting to use it will cause the trx to be rejected by peers of the interim X wallet and may cause a split between the two version of the software.
As mining is by no means recommended on the C# node on the stratis mainnet this should not be a problem.
 
- Creating a new op code OP_WITHDRAWPROOFVERIFY
- Writing the evaluation code to verify the new op code
- Building an SPV proof
- Verifying the SPV Proof
- Writing a test to simulate a transfer between two chains