### PR TITLE
The problem is coming from a call to an overloaded method with a seri…

### DIFF
--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -411,13 +411,14 @@ namespace NBitcoin.Tests
 				PeersToDiscover = 50
 			});
 			watch.Start();
-			using(var node = Node.Connect(Network.Main, parameters))
+			IPEndPoint[] connectedEndpoints = null;
+			using (var node = Node.Connect(Network.Main, parameters, connectedEndpoints))
 			{
 				var timeToFind = watch.Elapsed;
 				node.VersionHandshake();
 				node.Dispose();
 				watch.Restart();
-				using(var node2 = Node.Connect(Network.Main, parameters))
+				using (var node2 = Node.Connect(Network.Main, parameters, connectedEndpoints))
 				{
 					var timeToFind2 = watch.Elapsed;
 				}

--- a/NBitcoin.Tests/pos_ProtocolTests.cs
+++ b/NBitcoin.Tests/pos_ProtocolTests.cs
@@ -272,13 +272,14 @@ namespace NBitcoin.Tests
 			var addrman = GetCachedAddrMan("addrmancache.dat");
 			parameters.TemplateBehaviors.Add(new AddressManagerBehavior(addrman));
 			watch.Start();
-			using (var node = Node.Connect(Network.StratisMain, parameters))
+			IPEndPoint[] connectedEndpoints = null;
+			using (var node = Node.Connect(Network.StratisMain, parameters, connectedEndpoints))
 			{
 				var timeToFind = watch.Elapsed;
 				node.VersionHandshake();
 				node.Dispose();
 				watch.Restart();
-				using (var node2 = Node.Connect(Network.StratisMain, parameters))
+				using (var node2 = Node.Connect(Network.StratisMain, parameters, connectedEndpoints))
 				{
 					var timeToFind2 = watch.Elapsed;
 				}


### PR DESCRIPTION
…es of params that default to Null and the compiler can't tell which one to call.  By explicitly setting IPEndPoint[] connectedEndpoints = null and then passing in connectedEndpoints the compiler knows what to do.