### PR TITLE
Fix ambiguous Connect method

### DIFF
--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -525,7 +525,7 @@ namespace NBitcoin.Protocol
 		/// <param name="connectedEndpoints">Function returning the already connected endpoints, the new endpoint will be select outside of existing groups</param>
 		/// <param name="getGroup">Group selector, by default NBicoin.IpExtensions.GetGroup</param>
 		/// <returns></returns>
-		public static Node Connect(Network network, NodeConnectionParameters parameters = null, Func<IPEndPoint[]> connectedEndpoints = null, Func<IPEndPoint, byte[]> getGroup = null)
+		public static Node Connect(Network network, NodeConnectionParameters parameters, Func<IPEndPoint[]> connectedEndpoints, Func<IPEndPoint, byte[]> getGroup = null)
 		{
 			getGroup = getGroup ?? new Func<IPEndPoint, byte[]>((a) => IpExtensions.GetGroup(a.Address));
 			connectedEndpoints = connectedEndpoints ?? new Func<IPEndPoint[]>(() => new IPEndPoint[0]);


### PR DESCRIPTION
This PR:

- Updates a recently added "Connect" method changing optional arguments that lead to ambiguous method calls to non-optional.