### PR TITLE
Memory leak fixes for node [Part 2]

### DIFF
--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -403,26 +403,27 @@ namespace NBitcoin.Tests
 		[Fact]
 		public void CanConnectToRandomNode()
 		{
-			Stopwatch watch = new Stopwatch();
-			NodeConnectionParameters parameters = new NodeConnectionParameters();
+			var watch = new Stopwatch();
+			var parameters = new NodeConnectionParameters();
+
 			var addrman = GetCachedAddrMan("addrmancache.dat");
 			parameters.TemplateBehaviors.Add(new AddressManagerBehavior(addrman)
 			{
 				PeersToDiscover = 50
 			});
+
 			watch.Start();
-			IPEndPoint[] connectedEndpoints = null;
-			using (var node = Node.Connect(Network.Main, parameters, connectedEndpoints))
-			{
-				var timeToFind = watch.Elapsed;
-				node.VersionHandshake();
-				node.Dispose();
-				watch.Restart();
-				using (var node2 = Node.Connect(Network.Main, parameters, connectedEndpoints))
-				{
-					var timeToFind2 = watch.Elapsed;
-				}
-			}
+
+			Node node = Node.Connect(Network.Main, parameters);
+			TimeSpan timeToFind = watch.Elapsed;
+			node.VersionHandshake();
+			node.Disconnect();
+
+			watch.Restart();
+			Node node2 = Node.Connect(Network.Main, parameters);
+			TimeSpan timeToFind2 = watch.Elapsed;
+			node.Disconnect();
+
 			addrman.SavePeerFile("addrmancache.dat", Network.Main);
 		}
 

--- a/NBitcoin/Protocol/MessageListener.cs
+++ b/NBitcoin/Protocol/MessageListener.cs
@@ -1,4 +1,5 @@
 ﻿#if !NOSOCKET
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -9,7 +10,6 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.Protocol
 {
-
 	public interface MessageListener<in T>
 	{
 		void PushMessage(T message);
@@ -35,6 +35,7 @@ namespace NBitcoin.Protocol
 				throw new ArgumentNullException("process");
 			_Process = process;
 		}
+
 		#region MessageListener<T> Members
 
 		public void PushMessage(T message)
@@ -85,6 +86,7 @@ namespace NBitcoin.Protocol
 				}
 			})).Start();
 		}
+
 		BlockingCollection<T> _MessageQueue = new BlockingCollection<T>(new ConcurrentQueue<T>());
 		public BlockingCollection<T> MessageQueue
 		{
@@ -93,7 +95,6 @@ namespace NBitcoin.Protocol
 				return _MessageQueue;
 			}
 		}
-
 
 		#region MessageListener Members
 
@@ -107,20 +108,21 @@ namespace NBitcoin.Protocol
 		#region IDisposable Members
 
 		CancellationTokenSource cancellationSource = new CancellationTokenSource();
+
 		public void Dispose()
 		{
 			if(cancellationSource.IsCancellationRequested)
 				return;
+
 			cancellationSource.Cancel();
+			cancellationSource.Dispose();
 		}
 
 		#endregion
-
 	}
 
 	public class PollMessageListener<T> : MessageListener<T>
 	{
-
 		BlockingCollection<T> _MessageQueue = new BlockingCollection<T>(new ConcurrentQueue<T>());
 		public BlockingCollection<T> MessageQueue
 		{
@@ -145,4 +147,5 @@ namespace NBitcoin.Protocol
 		#endregion
 	}
 }
+
 #endif

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -297,7 +297,7 @@ namespace NBitcoin.Protocol
 				if(Node.State != NodeState.Failed)
 					Node.State = NodeState.Offline;
 
-				if(_Cancel.IsCancellationRequested == false)
+				if (_Cancel.IsCancellationRequested == false)
 					_Cancel.Cancel();
 
 				if(_Disconnected.GetSafeWaitHandle().IsClosed == false)
@@ -963,6 +963,13 @@ namespace NBitcoin.Protocol
 			}
 		}
 
+		public TPayload ReceiveMessage<TPayload>(TimeSpan timeout) where TPayload : Payload
+		{
+			var source = new CancellationTokenSource();
+			source.CancelAfter(timeout);
+			return ReceiveMessage<TPayload>(source.Token);
+		}
+
 		public TPayload ReceiveMessage<TPayload>(CancellationToken cancellationToken = default(CancellationToken)) where TPayload : Payload
 		{
 			using(var listener = new NodeListener(this))
@@ -1090,10 +1097,6 @@ namespace NBitcoin.Protocol
 			{
 				AssertNoListeningThread();
 				_Connection.Disconnected.WaitOne();
-			}
-			catch (InvalidOperationException)
-			{
-				throw;
 			}
 			finally
 			{

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -1101,7 +1101,7 @@ namespace NBitcoin.Protocol
 
 			try
 			{
-				AssertListenerThreadIsNotCurrentThread();
+				AssertNoListeningThread();
 				_Connection.Disconnected.WaitOne();
 			}
 			catch (InvalidOperationException)
@@ -1146,7 +1146,7 @@ namespace NBitcoin.Protocol
 			}
 		}
 
-		private void AssertListenerThreadIsNotCurrentThread()
+		private void AssertNoListeningThread()
 		{
 			if (_Connection._ListenerThreadId == Thread.CurrentThread.ManagedThreadId)
 				throw new InvalidOperationException("Using Disconnect on this thread would result in a deadlock, use DisconnectAsync instead");
@@ -1413,7 +1413,7 @@ namespace NBitcoin.Protocol
 		/// <exception cref="System.InvalidOperationException">Thrown if used on the listener's thread, as it would result in a deadlock</exception>
 		public NodeListener CreateListener()
 		{
-			AssertListenerThreadIsNotCurrentThread();
+			AssertNoListeningThread();
 			return new NodeListener(this);
 		}
 


### PR DESCRIPTION
Cleanup Node's disconnect methods.
Rename NodeConnection.CleanUp() > EndListen()

This relates to [#569.](https://github.com/stratisproject/StratisBitcoinFullNode/issues/569)